### PR TITLE
Enforced astropy version in docker base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -93,7 +93,7 @@ RUN pip install \
         scipy \
         h5py \
         pyephem==3.7.6.0 && \
-    pip install "astropy<3.2" && \
+    pip install astropy==4.0.1.post1 && \
     pip install aipy && \
     pip install lsl
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -93,7 +93,6 @@ RUN pip install \
         scipy \
         h5py \
         pyephem==3.7.6.0 && \
-    pip install astropy==4.0.1.post1 && \
     pip install aipy && \
     pip install lsl
 


### PR DESCRIPTION
This fixes the error resolved in [this issue](https://github.com/lwa-project/lsl/issues/7).

Before this fix running `sessionGUI.py` after doing a session_schedules pull (`docker pull lwaproject/lsl:session_schedules`) fails with

> `ValueError: Coordinate frame name "barycentricmeanecliptic" is not a known coordinate frame (['altaz', 'barycentrictrueecliptic', 'cirs', 'fk4', 'fk4noeterms', 'fk5', 'galactic', 'galacticlsr', 'galactocentric', 'gcrs', 'geocentrictrueecliptic', 'hcrs', 'heliocentrictrueecliptic', 'icrs', 'itrs', 'lsr', 'precessedgeocentric', 'supergalactic'])`

I have tested by building base then building session_schedules on top of it.